### PR TITLE
Batch Jobs: Delete pool using required flag

### DIFF
--- a/iaas/batch/cli/batch.ps1
+++ b/iaas/batch/cli/batch.ps1
@@ -64,5 +64,5 @@ az batch task file download `
  --file-path stdout.txt `
  --destination ./stdout0.txt
 
-az batch pool delete -n $poolName
+az batch pool delete --pool-id $poolName
 az group delete -n $rgName


### PR DESCRIPTION
The `az batch pool delete` command requires the --pool-id flag.